### PR TITLE
print assertion errors in plain text

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,14 +34,19 @@ const getAssertionErrors = (testResults) => {
 export const checkAndPrintAssertionErrors = (trialRes) => {
     let assertionErrorsPerRequest = getAssertionErrors(trialRes);
     if (!isEmptyObj(assertionErrorsPerRequest)) {
-        console.error('\x1b[31m', 'Test assertions failures -', '\x1b[0m'); // ,`${JSON.stringify(assertionErrors, null, 4)}`);
+        console.error('\x1b[31m', 'Test failures -', '\x1b[0m');
 
         for (let requestIndex in assertionErrorsPerRequest) {
             let request = trialRes.resolvedRequests[requestIndex];
-            let description = request.description || requestIndex
-                + " - " + request.method + " " + request.url;
+            let description = request.description || requestIndex;
 
-            console.log("In request", description);
+            if (assertionErrorsPerRequest[requestIndex].length == 0) {
+                // If there was a failure but no assertion failed this means the request itself failed
+                console.log(`Failed request "${description}" - ${request.method} ${request.url}`);
+                console.log(`Status: ${request.response.status} ${request.response.statusText}`);
+            } else {
+                console.log(`Assertion errors in request "${description}" - ${request.method} ${request.url}`);
+            }
 
             for (let error of assertionErrorsPerRequest[requestIndex]) {
                 const parameter = error.check;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,7 +43,15 @@ export const checkAndPrintAssertionErrors = (trialRes) => {
             if (assertionErrorsPerRequest[requestIndex].length == 0) {
                 // If there was a failure but no assertion failed this means the request itself failed
                 console.log(`Failed request "${description}" - ${request.method} ${request.url}`);
-                console.log(`Status: ${request.response.status} ${request.response.statusText}`);
+                if (request.response) {
+                    console.log(`Status: ${request.response.status} ${request.response.statusText}`);
+                }
+
+                let histogram = trialRes.failures[requestIndex].histogram;
+                for (let errorKey in histogram) {
+                    console.log(`Error: ${errorKey}`);
+                }
+
             } else {
                 console.log(`Assertion errors in request "${description}" - ${request.method} ${request.url}`);
             }


### PR DESCRIPTION
Related to https://github.com/loadmill/loadmill/issues/745

In case of request error:
![image](https://user-images.githubusercontent.com/5776439/53699889-96ee6b00-3df5-11e9-8c4b-91c597c6ed3e.png)

In case of an assertion error:
![image](https://user-images.githubusercontent.com/5776439/53699914-d7e67f80-3df5-11e9-9d29-5f34af4e2a89.png)

Can be tested with this test json
[fail_demo.json.txt](https://github.com/loadmill/loadmill-node/files/2923492/fail_demo.json.txt)

![](https://media.giphy.com/media/kQbMO5X7UA1C8/giphy.gif)
